### PR TITLE
Add support for flex-basis

### DIFF
--- a/src/plugins.ts
+++ b/src/plugins.ts
@@ -163,6 +163,9 @@ export const functionalPlugins = new Map<string, FunctionalPlugin[]>([
     ["flex", [
         {scaleKey: "flex", ns: 'flex', class: ['flex'], type: 'number'},
     ]],
+    ["basis", [
+        {scaleKey: "flexBasis", ns: 'flexBasis', class: ['flex-basis'], type: 'length'},
+    ]],
     ["grid-cols", [
         {scaleKey: "gridTemplateColumns", ns: 'gridTemplateColumns', class: ['grid-template-columns'], type: 'number'},
     ]],
@@ -474,6 +477,10 @@ export const namedPlugins = new Map<string, NamedPlugin>([
     ["shrink-0", {class: ['flex-shrink'], value: '0', ns: 'flexShrink'}],
     ["flex-shrink", {class: ['flex-shrink'], value: '1', ns: 'flexShrink'}],
     ["flex-shrink-0", {class: ['flex-shrink'], value: '0', ns: 'flexShrink'}],
+
+    // Flex Basis
+    ['basis-auto', { class: ['flex-basis'], value: 'auto', ns: 'flexBasis' }],
+    ['basis-full', { class: ['flex-basis'], value: '100%', ns: 'flexBasis' }],
 
     // Filters
     ["grayscale", {class: ['filter'], value: 'grayscale(100%)', ns: 'grayScale'}],

--- a/test/parse.test.ts
+++ b/test/parse.test.ts
@@ -221,3 +221,62 @@ it("should parse rounded corner classes", () => {
         variants: [],
     });
 });
+it('should parse flex-basis classes', () => {
+    expect(parse('basis-full')).toEqual({
+        "arbitrary": false,
+        "important": false,
+        "kind": "named",
+        "modifier": null,
+        "negative": false,
+        "property": "flexBasis",
+        "root": "basis-full",
+        "value": "100%",
+        "valueDef":  {
+        "class": [
+            "flex-basis",
+        ],
+        "kind": "named",
+        "raw": "basis-full",
+        "value": "100%",
+        },
+        "variants":  [],
+    })
+    expect(parse('basis-auto')).toEqual({
+        "arbitrary": false,
+        "important": false,
+        "kind": "named",
+        "modifier": null,
+        "negative": false,
+        "property": "flexBasis",
+        "root": "basis-auto",
+        "value": "auto",
+        "valueDef":  {
+        "class": [
+            "flex-basis",
+        ],
+        "kind": "named",
+        "raw": "basis-auto",
+        "value": "auto",
+        },
+        "variants":  [],
+    })
+    expect(parse('basis-7')).toEqual({
+        "arbitrary": false,
+        "important": false,
+        "kind": "functional",
+        "modifier": null,
+        "negative": false,
+        "property": "flexBasis",
+        "root": "basis",
+        "value": "1.75rem",
+        "valueDef":  {
+        "class": [
+            "flex-basis",
+        ],
+        "kind": "length",
+        "raw": "7",
+        "value": "1.75rem",
+        },
+        "variants":  [],
+    })
+})


### PR DESCRIPTION
This PR adds support for `flex-basis` (Tailwind reference: https://tailwindcss.com/docs/flex-basis). Specifically, the following props are added:
- `basis-auto`: turns into `flex-basis: auto;`
- `basis-full`: turns into `flex-basis: 100%;`
- `basis-*`: turns into `flex-basis: <the appropriate value based on the spacings>`