### PR TITLE
Fix parsing inset classes

### DIFF
--- a/src/plugins.ts
+++ b/src/plugins.ts
@@ -246,15 +246,9 @@ export const functionalPlugins = new Map<string, FunctionalPlugin[]>([
         {scaleKey: "inset", ns: 'inset', class: ['inset'], type: 'length', supportNegative: true},
     ]],
     ["inset-x", [
-        {scaleKey: "inset", ns: 'insetX', class: ['inset-x'], type: 'length', supportNegative: true},
-    ]],
-    ["inset-x", [
-        {scaleKey: "inset", ns: 'insetY', class: ['inset'], type: 'length', supportNegative: true},
-    ]],
-    ["inset-x", [
         {scaleKey: "inset", ns: 'insetX', class: ['left', 'right'], type: 'length', supportNegative: true},
     ]],
-    ["inset-x", [
+    ["inset-y", [
         {scaleKey: "inset", ns: 'insetY', class: ['top', 'bottom'], type: 'length', supportNegative: true},
     ]],
     ["top", [

--- a/test/parse.test.ts
+++ b/test/parse.test.ts
@@ -280,3 +280,64 @@ it('should parse flex-basis classes', () => {
         "variants":  [],
     })
 })
+it('should parse inset classes', () => {
+    expect(parse('inset-2')).toEqual({
+        "arbitrary": false,
+        "important": false,
+        "kind": "functional",
+        "modifier": null,
+        "negative": false,
+        "property": "inset",
+        "root": "inset",
+        "value": "0.5rem",
+        "valueDef": {
+        "class": [
+            "inset",
+        ],
+        "kind": "length",
+        "raw": "2",
+        "value": "0.5rem",
+        },
+        "variants": [],
+    })
+    expect(parse('inset-y-2')).toEqual({
+        "arbitrary": false,
+        "important": false,
+        "kind": "functional",
+        "modifier": null,
+        "negative": false,
+        "property": "insetY",
+        "root": "inset-y",
+        "value": "0.5rem",
+        "valueDef": {
+          "class": [
+            "top",
+            "bottom",
+          ],
+          "kind": "length",
+          "raw": "2",
+          "value": "0.5rem",
+        },
+        "variants": [],
+    })
+    expect(parse('inset-x-2')).toEqual({
+        "arbitrary": false,
+        "important": false,
+        "kind": "functional",
+        "modifier": null,
+        "negative": false,
+        "property": "insetX",
+        "root": "inset-x",
+        "value": "0.5rem",
+        "valueDef": {
+          "class": [
+            "left",
+            "right",
+          ],
+          "kind": "length",
+          "raw": "2",
+          "value": "0.5rem",
+        },
+        "variants": [],
+    })
+})


### PR DESCRIPTION
This PR fixes the following bugs:
- `inset-x` is parsed as `insetY`, setting `top` and bottom`.
- parsing `inset-y` fails with the following message:
```
{
  root: "inset-y-2",
  kind: "error",
  message: "found \"inset\" plugins but unable to determine which one is matched to given value \"y-2\"."
}
```

This PR updates the hardcoded plugins for `inset`, `inset-x` and `inset-y` to match the Tailwind spec.